### PR TITLE
Prevent user enumeration on reset, use an actor for sending email asynchronously

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -52,5 +52,8 @@ mail.reset.ask.subject=Play20StartApp - New password
 # Cannot use You've unescaped here, as the single quote stops the {0}
 mail.reset.ask.message=You asked for your password to be reset.  <br> Click on this link : {0} to change your password.
 
+mail.reset.fail.subject=Account Access Attempted
+mail.reset.fail.message=You (or someone else) entered this email address when trying to change the password.  However, this email address is not on our list of registered users, and so the attempted password reset has failed.
+
 mail.reset.confirm.subject=Play20StartApp - New password
 mail.reset.confirm.message=Your password has been reset.

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -51,5 +51,8 @@ mail.welcome.message=Bienvenue sur Play20StartApp. <br><br> Votre compte est val
 mail.reset.ask.subject=Play20StartApp - Changement de mot de passe ?
 mail.reset.ask.message=Bonjour, <br><br> Cliquez ici : {0} pour confirmer votre demande de changement de mot de passe.
 
+mail.reset.fail.subject=Account Access Attempted
+mail.reset.fail.message=You (or someone else) entered this email address when trying to change the password.  However, this email address is not on our list of registered users, and so the attempted password reset has failed.
+
 mail.reset.confirm.subject=Play20StartApp - Changement de mot de passe
 mail.reset.confirm.message=Bonjour, <br><br> Votre mot de passe a été changé.


### PR DESCRIPTION
Hi Yvonnick,

Two minor changes -- I changed the Mailing class so it uses an Akka actor now so that email is sent asynchronously and doesn't block the main render thread, and I changed the reset code so that it doesn't show who is a valid user and who is not to prevent user enumeration attacks, based off some information in  http://www.troyhunt.com/2012/05/everything-you-ever-wanted-to-know.html.

Will.
