### PR TITLE
Correction for: unresolved dependency: org.scala-sbt#sbt_2.9.1;0.11.2: not found

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3


### PR DESCRIPTION
Correction for: unresolved dependency: org.scala-sbt#sbt_2.9.1;0.11.2: not found

It doesn't look like 11.2 is hosted in the typesafe repo any more.
http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt_2.9.1/
